### PR TITLE
replace wpscholar collection package with wp-force equivalent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ]
   },
   "require": {
-    "wpscholar/collection": "^1.0",
     "wp-forge/wp-htaccess-manager": "^1.0",
-    "wpscholar/url": "^1.2"
+    "wpscholar/url": "^1.2",
+    "wp-forge/collection": "^1.0"
   }
 }

--- a/includes/CacheManager.php
+++ b/includes/CacheManager.php
@@ -4,7 +4,7 @@ namespace NewfoldLabs\WP\Module\Performance;
 
 use NewfoldLabs\WP\Module\Performance\CacheTypes\CacheBase;
 use NewfoldLabs\WP\ModuleLoader\Container;
-use wpscholar\Collection;
+use WP_Forge\Collection\Collection;
 
 class CacheManager {
 


### PR DESCRIPTION
Getting warnings for `Package wpscholar/collection is abandoned, you should avoid using it. No replacement was suggested.` so I updated it to use the equivalent wp-forge package.