### PR TITLE
add a check that $path is_dir before trying to load its files

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -97,6 +97,9 @@ function shouldCacheAssets() {
  * @param string $path
  */
 function removeDirectory( $path ) {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
 	$files = glob( $path . '/*' );
 	foreach ( $files as $file ) {
 		is_dir( $file ) ? removeDirectory( $file ) : unlink( $file );


### PR DESCRIPTION
Fix #3 issue when path is not found and gives a fatal error.

If the path is not found we can just return since there's nothing to do.