### PR TITLE
Add ads.txt to rewrite exclusions

### DIFF
--- a/includes/CacheTypes/Skip404.php
+++ b/includes/CacheTypes/Skip404.php
@@ -81,7 +81,7 @@ class Skip404 extends CacheBase {
 	RewriteEngine On
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteCond %{REQUEST_URI} !(robots\.txt|[a-z0-9_\-]*sitemap[a-z0-9_\.\-]*\.(xml|xsl|html)(\.gz)?)
+	RewriteCond %{REQUEST_URI} !(robots\.txt|ads\.txt|[a-z0-9_\-]*sitemap[a-z0-9_\.\-]*\.(xml|xsl|html)(\.gz)?)
 	RewriteCond %{REQUEST_URI} \.(css|htc|less|js|js2|js3|js4|html|htm|rtf|rtx|txt|xsd|xsl|xml|asf|asx|wax|wmv|wmx|avi|avif|avifs|bmp|class|divx|doc|docx|eot|exe|gif|gz|gzip|ico|jpg|jpeg|jpe|webp|json|mdb|mid|midi|mov|qt|mp3|m4a|mp4|m4v|mpeg|mpg|mpe|webm|mpp|otf|_otf|odb|odc|odf|odg|odp|ods|odt|ogg|ogv|pdf|png|pot|pps|ppt|pptx|ra|ram|svg|svgz|swf|tar|tif|tiff|ttf|ttc|_ttf|wav|wma|wri|woff|woff2|xla|xls|xlsx|xlt|xlw|zip)$ [NC]
 	RewriteRule .* - [L]
 </IfModule>


### PR DESCRIPTION
Like robots.txt, ads.txt is an expected file at the root of an ad-serving publisher's domain. It is is a standard for publishers to increase transparency in the programmatic advertising ecosystem. For more information, see https://iabtechlab.com/ads-txt/

I am proposing this change because several publishers we work with on the [SHE Media Collective](https://www.shemedia.com/) have run into an issue where the WordPress redirect to this file from our plugin is not working as expected. I would expect that other publishers on other ad networks may have the same issue. 

