### PR TITLE
Fix file based cache generating multiple cache directories in `wp-content`

### DIFF
--- a/includes/CacheTypes/File.php
+++ b/includes/CacheTypes/File.php
@@ -21,7 +21,7 @@ class File extends CacheBase implements Purgeable {
 	 *
 	 * @var string
 	 */
-	const CACHE_DIR = WP_CONTENT_DIR . '/newfold-page-cache';
+	const CACHE_DIR = WP_CONTENT_DIR . '/newfold-page-cache/';
 
 	/**
 	 * The file marker name.


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue where file-based caching generates multiple cache directories in `wp-content` instead of putting them all in the `wp-content/newfold-page-cache`.

This PR aims to address this internal ticket: https://jira.newfold.com/browse/PRESS0-1028

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
