### PR TITLE
filter action scheduler retention period and batch size

### DIFF
--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -136,12 +136,18 @@ class Performance {
 	/**
 	 * Update the default action scheduler retention period to 5 days instead of 30.
 	 * The actions scheduler table tends to grow to gigantic sizes and this should help.
-	 * 
-	 * @return int new retention period
+	 *
+	 * @hooked action_scheduler_retention_period
+	 * @see ActionScheduler_QueueCleaner::delete_old_actions()
+	 *
+	 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
+	 *
+	 * @return int New retention period in seconds.
 	 */
-	function nfd_asr_default() {  
-		return 5 * DAY_IN_SECONDS;  
+	public function nfd_asr_default( $retention_period ) {
+		return 5 * constant( 'DAY_IN_SECONDS' );
 	}
+
 	/**
 	 * When updating mod rewrite rules, also update our rewrites as appropriate.
 	 */

--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -105,7 +105,7 @@ class Performance {
 
 	/**
 	 * Add hooks.
-	 * 
+	 *
 	 * @param Container $container the container
 	 */
 	public function hooks( Container $container ) {

--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -130,9 +130,18 @@ class Performance {
 		);
 
 		add_action( 'after_mod_rewrite_rules', [ $this, 'onRewrite' ] );
-
+		add_filter( 'action_scheduler_retention_period', array( $this, 'nfd_asr_default' ) );  
 	}
 
+	/**
+	 * Update the default action scheduler retention period to 5 days instead of 30.
+	 * The actions scheduler table tends to grow to gigantic sizes and this should help.
+	 * 
+	 * @return int new retention period
+	 */
+	function nfd_asr_default() {  
+		return 5 * DAY_IN_SECONDS;  
+	}
 	/**
 	 * When updating mod rewrite rules, also update our rewrites as appropriate.
 	 */

--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -71,7 +71,7 @@ class Performance {
 
 		// Ensure that purgeable cache types are enabled before showing the UI.
 		if ( $cachePurger->canPurge() ) {
-			add_action( 'admin_bar_menu', [ $this, 'adminBarMenu' ], 100 );
+			add_action( 'admin_bar_menu', array( $this, 'adminBarMenu' ), 100 );
 		}
 
 		$container->set( 'cachePurger', $cachePurger );
@@ -102,9 +102,9 @@ class Performance {
 	 */
 	public function hooks( Container $container ) {
 
-		add_action( 'admin_init', [ $this, 'registerSettings' ], 11 );
+		add_action( 'admin_init', array( $this, 'registerSettings' ), 11 );
 
-		new OptionListener( self::OPTION_CACHE_LEVEL, [ $this, 'onCacheLevelChange' ] );
+		new OptionListener( self::OPTION_CACHE_LEVEL, array( $this, 'onCacheLevelChange' ) );
 
 		/**
 		 * On CLI requests, mod_rewrite is unavailable, so it fails to update
@@ -129,7 +129,7 @@ class Performance {
 			}
 		);
 
-		add_action( 'after_mod_rewrite_rules', [ $this, 'onRewrite' ] );
+		add_action( 'after_mod_rewrite_rules', array( $this, 'onRewrite' ) );
 		add_filter( 'action_scheduler_retention_period', array( $this, 'nfd_asr_default' ) );  
 	}
 
@@ -213,42 +213,40 @@ class Performance {
 		if ( current_user_can( 'manage_options' ) ) {
 
 			$wp_admin_bar->add_node(
-				[
+				array(
 					'id'    => 'nfd_purge_menu',
 					'title' => __( 'Caching', 'newfold-module-performance' ),
-				]
+				)
 			);
 
 			$wp_admin_bar->add_node(
-				[
+				array(
 					'id'     => 'nfd_purge_menu-purge_all',
 					'title'  => __( 'Purge All', 'newfold-module-performance' ),
 					'parent' => 'nfd_purge_menu',
-					'href'   => add_query_arg( [ self::PURGE_ALL => true ] ),
-				]
+					'href'   => add_query_arg( array( self::PURGE_ALL => true ) ),
+				)
 			);
 
 			if ( ! is_admin() ) {
 				$wp_admin_bar->add_node(
-					[
+					array(
 						'id'     => 'nfd_purge_menu-purge_single',
 						'title'  => __( 'Purge This Page', 'newfold-module-performance' ),
 						'parent' => 'nfd_purge_menu',
-						'href'   => add_query_arg( [ self::PURGE_URL => true ] ),
-					]
+						'href'   => add_query_arg( array( self::PURGE_URL => true ) ),
+					)
 				);
 			}
 
 			$wp_admin_bar->add_node(
-				[
+				array(
 					'id'     => 'nfd_purge_menu-cache_settings',
 					'title'  => __( 'Cache Settings', 'newfold-module-performance' ),
 					'parent' => 'nfd_purge_menu',
 					'href'   => admin_url( 'options-general.php#' . Performance::SETTINGS_ID ),
-				]
+				)
 			);
 		}
-
 	}
-
 }

--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -7,6 +7,9 @@ use NewfoldLabs\WP\Module\Performance\CacheTypes\File;
 use NewfoldLabs\WP\Module\Performance\CacheTypes\Skip404;
 use NewfoldLabs\WP\ModuleLoader\Container;
 
+/**
+ * Performance Class
+ */
 class Performance {
 
 	/**
@@ -57,7 +60,7 @@ class Performance {
 	/**
 	 * Constructor.
 	 *
-	 * @param Container $container
+	 * @param Container $container the container
 	 */
 	public function __construct( Container $container ) {
 
@@ -77,9 +80,13 @@ class Performance {
 		$container->set( 'cachePurger', $cachePurger );
 
 		$container->set( 'hasMustUsePlugin', file_exists( WPMU_PLUGIN_DIR . '/endurance-page-cache.php' ) );
-
 	}
 
+	/**
+	 * Constructor.
+	 *
+	 * @param Container $container the container
+	 */
 	public function configureContainer( Container $container ) {
 
 		global $is_apache;
@@ -94,11 +101,12 @@ class Performance {
 				}
 			)
 		);
-
 	}
 
 	/**
 	 * Add hooks.
+	 * 
+	 * @param Container $container the container
 	 */
 	public function hooks( Container $container ) {
 
@@ -186,6 +194,8 @@ class Performance {
 	 */
 	public function onCacheLevelChange( $cacheLevel ) {
 		/**
+		 * Respone Header Manager from container
+		 *
 		 * @var ResponseHeaderManager $responseHeaderManager
 		 */
 		$responseHeaderManager = $this->container->get( 'responseHeaderManager' );
@@ -198,6 +208,9 @@ class Performance {
 		}
 	}
 
+	/**
+	 * Register settings
+	 */
 	public function registerSettings() {
 
 		global $wp_settings_fields;
@@ -231,7 +244,7 @@ class Performance {
 	/**
 	 * Add options to the WordPress admin bar.
 	 *
-	 * @param \WP_Admin_Bar $wp_admin_bar
+	 * @param \WP_Admin_Bar $wp_admin_bar the admin bar
 	 */
 	public function adminBarMenu( \WP_Admin_Bar $wp_admin_bar ) {
 


### PR DESCRIPTION
## Proposed changes

We identified an issue where the action scheduler tables used by WooCommerce and other plugins accumulate an excessive amount of data, sometimes reaching up to 20 GB. This is because expired actions are retained in the database for 30 days by default, allowing the table size to grow uncontrollably, even reaching 100 GB in some cases.

As a quick and straightforward fix, this PR changes the default retention period from 30 days to 5 days. This adjustment should significantly reduce the table size and prevent database bloat without requiring extensive code changes.

See ticket PRESS0-2085

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes (My changes are good, but don't have time to update the whole file with docs. I made the easy fixes.)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
