### PR TITLE
Fix Skip 404 settings appearance

### DIFF
--- a/components/performance/defaultText.js
+++ b/components/performance/defaultText.js
@@ -80,7 +80,7 @@ const defaultText = {
 		'wp-module-performance'
 	),
 	skip404OptionLabel: __(
-		'Skip 404 Handling For Static Files',
+		'Enable Skip 404 Handling For Static Files',
 		'wp-module-performance'
 	),
 	skip404NoticeTitle: __( 'Skip 404 saved', 'wp-module-performance' ),

--- a/components/skip404/index.js
+++ b/components/skip404/index.js
@@ -2,7 +2,7 @@
 import apiFetch from '@wordpress/api-fetch';
 
 // Newfold
-import { Checkbox, Container } from '@newfold/ui-component-library';
+import { ToggleField, Container } from '@newfold/ui-component-library';
 import { NewfoldRuntime } from '@newfold/wp-module-runtime';
 
 const Skip404 = ( { methods, constants } ) => {
@@ -53,13 +53,11 @@ const Skip404 = ( { methods, constants } ) => {
 			title={ constants.text.skip404Title }
 			description={ constants.text.skip404Description }
 		>
-			<Checkbox
+			<ToggleField
 				id="skip-404"
-				name="skip-404"
-				onChange={ handleSkip404Change }
-				value={ skip404 }
-				checked={ skip404 }
 				label={ constants.text.skip404OptionLabel }
+				checked={ skip404 }
+				onChange={ () => handleSkip404Change( skip404, setSkip404 ) }
 			/>
 		</Container.SettingsField>
 	);


### PR DESCRIPTION
## Proposed changes

Makes the settings screen more consistent. Split from https://github.com/newfold-labs/wp-module-performance/pull/80

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

## Screenshots

Before:


![skip-404-before](https://github.com/user-attachments/assets/6289e554-d401-4998-ba16-dd9415cda63c)

After:

![skip-404](https://github.com/user-attachments/assets/5ee9dbce-636a-4f1d-a5c4-bd4e9c80a3a1)


## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)

