### PR TITLE
Fix Link Prefetch settings appearance

### DIFF
--- a/components/linkPrefetch/index.js
+++ b/components/linkPrefetch/index.js
@@ -1,5 +1,5 @@
 import {
-	Toggle,
+	ToggleField,
 	TextField,
 	SelectField,
 	Container,
@@ -65,29 +65,16 @@ const LinkPrefetch = ( { methods, constants } ) => {
 				title={ constants.text.linkPrefetchTitle }
 				description={ constants.text.linkPrefetchDescription }
 			>
-				{ /* Desktop Settings */ }
-				<div className="nfd-toggle-field nfd-mb-6">
-					<div>
-						<label
-							className="nfd-label"
-							htmlFor="link-prefetch-active-desktop"
-						>
-							{
-								constants.text
-									.linkPrefetchActivateOnDesktopLabel
-							}
-						</label>
-						<div className="nfd-select-field__description">
-							{
-								constants.text
-									.linkPrefetchActivateOnDesktopDescription
-							}
-						</div>
-					</div>
-					<Toggle
+				<div className="nfd-flex nfd-flex-col nfd-gap-6">
+					{ /* Desktop Settings */ }
+					<ToggleField
 						id="link-prefetch-active-desktop"
-						screenReaderLabel={
+						label={
 							constants.text.linkPrefetchActivateOnDesktopLabel
+						}
+						description={
+							constants.text
+								.linkPrefetchActivateOnDesktopDescription
 						}
 						checked={ settings.activeOnDesktop }
 						onChange={ () =>
@@ -97,67 +84,55 @@ const LinkPrefetch = ( { methods, constants } ) => {
 							)
 						}
 					/>
-				</div>
-				{ settings.activeOnDesktop && (
-					<SelectField
-						id="link-prefetch-behavior"
-						label={ constants.text.linkPrefetchBehaviorLabel }
-						value={ settings.behavior }
-						selectedLabel={
-							'mouseDown' === settings.behavior
-								? constants.text
-										.linkPrefetchBehaviorMouseDownLabel
-								: constants.text
+					{ settings.activeOnDesktop && (
+						<SelectField
+							id="link-prefetch-behavior"
+							label={ constants.text.linkPrefetchBehaviorLabel }
+							value={ settings.behavior }
+							selectedLabel={
+								'mouseDown' === settings.behavior
+									? constants.text
+											.linkPrefetchBehaviorMouseDownLabel
+									: constants.text
+											.linkPrefetchBehaviorMouseHoverLabel
+							}
+							onChange={ ( v ) =>
+								handleChangeOption( 'behavior', v )
+							}
+							description={
+								'mouseDown' === settings.behavior
+									? constants.text
+											.linkPrefetchBehaviorMouseDownDescription
+									: constants.text
+											.linkPrefetchBehaviorMouseHoverDescription
+							}
+							className="nfd-mb-6"
+						>
+							<SelectField.Option
+								label={
+									constants.text
 										.linkPrefetchBehaviorMouseHoverLabel
-						}
-						onChange={ ( v ) =>
-							handleChangeOption( 'behavior', v )
+								}
+								value="mouseHover"
+							/>
+							<SelectField.Option
+								label={
+									constants.text
+										.linkPrefetchBehaviorMouseDownLabel
+								}
+								value="mouseDown"
+							/>
+						</SelectField>
+					) }
+					{ /* Mobile Settings */ }
+					<ToggleField
+						id="link-prefetch-active-mobile"
+						label={
+							constants.text.linkPrefetchActivateOnMobileLabel
 						}
 						description={
-							'mouseDown' === settings.behavior
-								? constants.text
-										.linkPrefetchBehaviorMouseDownDescription
-								: constants.text
-										.linkPrefetchBehaviorMouseHoverDescription
-						}
-						className="nfd-mb-6"
-					>
-						<SelectField.Option
-							label={
-								constants.text
-									.linkPrefetchBehaviorMouseHoverLabel
-							}
-							value="mouseHover"
-						/>
-						<SelectField.Option
-							label={
-								constants.text
-									.linkPrefetchBehaviorMouseDownLabel
-							}
-							value="mouseDown"
-						/>
-					</SelectField>
-				) }
-				{ /* Mobile Settings */ }
-				<div className="nfd-toggle-field nfd-mb-6">
-					<div>
-						<label
-							className="nfd-label"
-							htmlFor="link-prefetch-active-mobile"
-						>
-							{ constants.text.linkPrefetchActivateOnMobileLabel }
-						</label>
-						<div className="nfd-select-field__description">
-							{
-								constants.text
-									.linkPrefetchActivateOnMobileDescription
-							}
-						</div>
-					</div>
-					<Toggle
-						id="link-prefetch-active-mobile"
-						screenReaderLabel={
-							constants.text.linkPrefetchActivateOnMobileLabel
+							constants.text
+								.linkPrefetchActivateOnMobileDescription
 						}
 						checked={ settings.activeOnMobile }
 						onChange={ () =>
@@ -167,61 +142,67 @@ const LinkPrefetch = ( { methods, constants } ) => {
 							)
 						}
 					/>
-				</div>
-				{ settings.activeOnMobile && (
-					<SelectField
-						id="link-prefetch-behavior-mobile"
-						label={ constants.text.linkPrefetchBehaviorLabel }
-						value={ settings.mobileBehavior }
-						selectedLabel={
-							'touchstart' === settings.mobileBehavior
-								? constants.text
+					{ settings.activeOnMobile && (
+						<SelectField
+							id="link-prefetch-behavior-mobile"
+							label={ constants.text.linkPrefetchBehaviorLabel }
+							value={ settings.mobileBehavior }
+							selectedLabel={
+								'touchstart' === settings.mobileBehavior
+									? constants.text
+											.linkPrefetchBehaviorMobileTouchstartLabel
+									: constants.text
+											.linkPrefetchBehaviorMobileViewportLabel
+							}
+							onChange={ ( v ) =>
+								handleChangeOption( 'mobileBehavior', v )
+							}
+							description={
+								'touchstart' === settings.mobileBehavior
+									? constants.text
+											.linkPrefetchBehaviorMobileTouchstartDescription
+									: constants.text
+											.linkPrefetchBehaviorMobileViewportDescription
+							}
+							className="nfd-mb-6"
+						>
+							<SelectField.Option
+								label={
+									constants.text
 										.linkPrefetchBehaviorMobileTouchstartLabel
-								: constants.text
+								}
+								value="touchstart"
+							/>
+							<SelectField.Option
+								label={
+									constants.text
 										.linkPrefetchBehaviorMobileViewportLabel
-						}
-						onChange={ ( v ) =>
-							handleChangeOption( 'mobileBehavior', v )
-						}
-						description={
-							'touchstart' === settings.mobileBehavior
-								? constants.text
-										.linkPrefetchBehaviorMobileTouchstartDescription
-								: constants.text
-										.linkPrefetchBehaviorMobileViewportDescription
-						}
-						className="nfd-mb-6"
-					>
-						<SelectField.Option
+								}
+								value="viewport"
+							/>
+						</SelectField>
+					) }
+					{ /* Ignore Keywords */ }
+					{ ( settings.activeOnMobile ||
+						settings.activeOnDesktop ) && (
+						<TextField
+							id="link-prefetch-ignore-keywords"
 							label={
-								constants.text
-									.linkPrefetchBehaviorMobileTouchstartLabel
+								constants.text.linkPrefetchIgnoreKeywordsLabel
 							}
-							value="touchstart"
-						/>
-						<SelectField.Option
-							label={
+							description={
 								constants.text
-									.linkPrefetchBehaviorMobileViewportLabel
+									.linkPrefetchIgnoreKeywordsDescription
 							}
-							value="viewport"
+							onChange={ ( e ) =>
+								handleChangeOptionIgnoreKeywords(
+									e.target.value
+								)
+							}
+							value={ ignoreKeywords }
 						/>
-					</SelectField>
-				) }
-				{ /* Ignore Keywords */ }
-				{ ( settings.activeOnMobile || settings.activeOnDesktop ) && (
-					<TextField
-						id="link-prefetch-ignore-keywords"
-						label={ constants.text.linkPrefetchIgnoreKeywordsLabel }
-						description={
-							constants.text.linkPrefetchIgnoreKeywordsDescription
-						}
-						onChange={ ( e ) =>
-							handleChangeOptionIgnoreKeywords( e.target.value )
-						}
-						value={ ignoreKeywords }
-					/>
-				) }
+					) }
+				</div>
 			</Container.SettingsField>
 		</>
 	);


### PR DESCRIPTION
## Proposed changes

Makes the settings screen more consistent. Split from https://github.com/newfold-labs/wp-module-performance/pull/80

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

## Screenshots

Before:

![link-prefetch-before](https://github.com/user-attachments/assets/77d62ea1-69b2-421c-bb96-b0cc968c2006)


After:

![link-prefetch](https://github.com/user-attachments/assets/b5b53349-e730-4ac8-9597-13382f9f9915)



## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)

