### PR TITLE
Add WP CLI commands for Image Optimization

### DIFF
--- a/includes/Images/ImageBulkOptimizer.php
+++ b/includes/Images/ImageBulkOptimizer.php
@@ -2,8 +2,6 @@
 
 namespace NewfoldLabs\WP\Module\Performance\Images;
 
-use function NewfoldLabs\WP\Module\Performance\is_bulk_image_optimizer_page;
-
 /**
  * Manages bulk optimization functionality for the Media Library.
  */

--- a/includes/Images/ImageSettings.php
+++ b/includes/Images/ImageSettings.php
@@ -196,4 +196,26 @@ class ImageSettings {
 		$settings = get_option( self::SETTING_KEY, self::DEFAULT_SETTINGS );
 		return ! empty( $settings['prefer_optimized_image_when_exists'] );
 	}
+
+	/**
+	 * Retrieves the image optimization settings.
+	 *
+	 * @return array The current image optimization settings.
+	 */
+	public static function get() {
+		return get_option( self::SETTING_KEY, self::DEFAULT_SETTINGS );
+	}
+
+	/**
+	 * Updates the image optimization settings.
+	 *
+	 * @param array $settings The new settings array.
+	 *
+	 * @return bool true if the settings were updated successfully, false otherwise.
+	 */
+	public static function update( $settings ) {
+		$instance           = new self();
+		$sanitized_settings = $instance->sanitize_settings( $settings );
+		return update_option( self::SETTING_KEY, $sanitized_settings );
+	}
 }

--- a/includes/Images/WPCLI/ImageCommandHandler.php
+++ b/includes/Images/WPCLI/ImageCommandHandler.php
@@ -186,9 +186,9 @@ class ImageCommandHandler {
 
 		ImageSettings::update( $settings );
 
-		/* translators: 1: the setting key, 2: the on/off status */
 		NFD_WPCLI::success(
 			sprintf(
+				/* translators: 1: the setting key, 2: the on/off status */
 				__( "Setting '%1\$s' has been turned %2\$s.", 'wp-module-performance' ),
 				$setting,
 				$status

--- a/includes/Images/WPCLI/ImageCommandHandler.php
+++ b/includes/Images/WPCLI/ImageCommandHandler.php
@@ -173,8 +173,19 @@ class ImageCommandHandler {
 			$settings['enabled'] = true;
 		}
 
+		// Update the specified setting.
 		$this->set_nested_value( $settings, $setting, $enabled );
+
+		// If both auto_optimize and bulk_optimization are turned off,
+		// then force auto_delete (auto_delete_original_image) to be off.
+		$auto_optimize     = ! empty( $settings['auto_optimized_uploaded_images']['enabled'] );
+		$bulk_optimization = ! empty( $settings['bulk_optimization'] );
+		if ( ! $auto_optimize && ! $bulk_optimization ) {
+			$settings['auto_optimized_uploaded_images']['auto_delete_original_image'] = false;
+		}
+
 		ImageSettings::update( $settings );
+
 		/* translators: 1: the setting key, 2: the on/off status */
 		NFD_WPCLI::success(
 			sprintf(
@@ -184,6 +195,7 @@ class ImageCommandHandler {
 			)
 		);
 	}
+
 
 	/**
 	 * Updates a nested setting value using dot notation.

--- a/includes/Images/WPCLI/ImageCommandHandler.php
+++ b/includes/Images/WPCLI/ImageCommandHandler.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Performance\Images\WPCLI;
+
+use NewfoldLabs\WP\Module\Performance\NFD_WPCLI;
+use NewfoldLabs\WP\Module\Performance\Images\ImageSettings;
+
+/**
+ * Handles WP-CLI commands for Image Optimization settings.
+ */
+class ImageCommandHandler {
+
+	/**
+	 * Allowed status values.
+	 *
+	 * @var array
+	 */
+	private const VALID_STATUSES = array( 'on', 'off' );
+
+	/**
+	 * Toggles the bulk optimization setting.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <status>
+	 * : Enable or disable bulk optimization. Accepts 'on' or 'off'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp nfd performance images bulk_optimization on
+	 *     wp nfd performance images bulk_optimization off
+	 *
+	 * @param array $args Positional arguments.
+	 *
+	 * @return void
+	 */
+	public function bulk_optimization( $args ) {
+		$status = $this->validate_status( isset( $args[0] ) ? $args[0] : null );
+		$this->toggle_setting( 'bulk_optimization', $status );
+	}
+
+	/**
+	 * Toggles lazy loading.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <status>
+	 * : Enable or disable lazy loading. Accepts 'on' or 'off'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp nfd performance images lazy_loading on
+	 *     wp nfd performance images lazy_loading off
+	 *
+	 * @param array $args Positional arguments.
+	 *
+	 * @return void
+	 */
+	public function lazy_loading( $args ) {
+		$status = $this->validate_status( isset( $args[0] ) ? $args[0] : null );
+		$this->toggle_setting( 'lazy_loading.enabled', $status );
+	}
+
+	/**
+	 * Toggles automatic optimization of uploaded images.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <status>
+	 * : Enable or disable auto-optimization. Accepts 'on' or 'off'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp nfd performance images auto_optimize on
+	 *     wp nfd performance images auto_optimize off
+	 *
+	 * @param array $args Positional arguments.
+	 *
+	 * @return void
+	 */
+	public function auto_optimize( $args ) {
+		$status = $this->validate_status( isset( $args[0] ) ? $args[0] : null );
+		$this->toggle_setting( 'auto_optimized_uploaded_images.enabled', $status );
+	}
+
+	/**
+	 * Toggles automatic deletion of the original image.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <status>
+	 * : Enable or disable auto-delete of original images. Accepts 'on' or 'off'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp nfd performance images auto_delete on
+	 *     wp nfd performance images auto_delete off
+	 *
+	 * @param array $args Positional arguments.
+	 *
+	 * @return void
+	 */
+	public function auto_delete( $args ) {
+		$status = $this->validate_status( isset( $args[0] ) ? $args[0] : null );
+		$this->toggle_setting( 'auto_optimized_uploaded_images.auto_delete_original_image', $status );
+	}
+
+	/**
+	 * Toggles WebP preference when optimized images exist.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <status>
+	 * : Enable or disable WebP preference. Accepts 'on' or 'off'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp nfd performance images webp_preference on
+	 *     wp nfd performance images webp_preference off
+	 *
+	 * @param array $args Positional arguments.
+	 *
+	 * @return void
+	 */
+	public function webp_preference( $args ) {
+		$status = $this->validate_status( isset( $args[0] ) ? $args[0] : null );
+		$this->toggle_setting( 'prefer_optimized_image_when_exists', $status );
+	}
+
+	/**
+	 * Toggles all image optimization settings at once.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <status>
+	 * : Enable or disable all image optimization settings. Accepts 'on' or 'off'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp nfd performance images all on
+	 *     wp nfd performance images all off
+	 *
+	 * @alias all
+	 *
+	 * @param array $args Positional arguments.
+	 *
+	 * @return void
+	 */
+	public function all( $args ) {
+		$status   = $this->validate_status( isset( $args[0] ) ? $args[0] : null );
+		$enabled  = ( 'on' === $status );
+		$settings = ImageSettings::get();
+		$this->set_all_values( $settings, $enabled );
+		ImageSettings::update( $settings );
+		/* translators: %s is the on/off status. */
+		NFD_WPCLI::success( sprintf( __( 'All image optimization settings have been turned %s.', 'wp-module-performance' ), $status ) );
+	}
+
+	/**
+	 * Toggles a specific image optimization setting.
+	 *
+	 * @param string $setting The setting key (use dot notation for nested values).
+	 * @param string $status  The status ('on' or 'off').
+	 *
+	 * @return void
+	 */
+	private function toggle_setting( $setting, $status ) {
+		$enabled  = ( 'on' === $status );
+		$settings = ImageSettings::get();
+
+		// If a feature is turned on (except for the "all" command), enable overall image optimization.
+		if ( $enabled ) {
+			$settings['enabled'] = true;
+		}
+
+		$this->set_nested_value( $settings, $setting, $enabled );
+		ImageSettings::update( $settings );
+		/* translators: 1: the setting key, 2: the on/off status */
+		NFD_WPCLI::success(
+			sprintf(
+				__( "Setting '%1\$s' has been turned %2\$s.", 'wp-module-performance' ),
+				$setting,
+				$status
+			)
+		);
+	}
+
+	/**
+	 * Updates a nested setting value using dot notation.
+	 *
+	 * @param array  $settings The settings array.
+	 * @param string $key      The nested key in dot notation.
+	 * @param mixed  $value    The new value to set.
+	 *
+	 * @return void
+	 */
+	private function set_nested_value( &$settings, $key, $value ) {
+		$keys = explode( '.', $key );
+		$temp = &$settings;
+		foreach ( $keys as $part ) {
+			if ( ! isset( $temp[ $part ] ) || ! is_array( $temp[ $part ] ) ) {
+				$temp[ $part ] = array();
+			}
+			$temp = &$temp[ $part ];
+		}
+		$temp = $value;
+	}
+
+	/**
+	 * Recursively updates all boolean settings within an array.
+	 *
+	 * @param array $settings The settings array to update.
+	 * @param bool  $enabled  The boolean value to set.
+	 *
+	 * @return void
+	 */
+	private function set_all_values( &$settings, $enabled ) {
+		foreach ( $settings as $key => &$value ) {
+			if ( is_array( $value ) ) {
+				$this->set_all_values( $value, $enabled );
+			} else {
+				$value = $enabled;
+			}
+		}
+	}
+
+	/**
+	 * Validates and normalizes the status input.
+	 *
+	 * @param string|null $status The input status.
+	 * @return string The normalized status.
+	 */
+	private function validate_status( $status ) {
+		if ( empty( $status ) ) {
+			NFD_WPCLI::error( __( "A status ('on' or 'off') is required.", 'wp-module-performance' ) );
+		}
+		$status = strtolower( $status );
+		if ( ! in_array( $status, self::VALID_STATUSES, true ) ) {
+			NFD_WPCLI::error( __( "Invalid status: Use 'on' or 'off'.", 'wp-module-performance' ) );
+		}
+		return $status;
+	}
+}

--- a/includes/NFD_WPCLI.php
+++ b/includes/NFD_WPCLI.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Performance;
+
+use WP_CLI;
+
+/**
+ * Manages all "nfd" WP-CLI commands.
+ */
+class NFD_WPCLI {
+
+	/**
+	 * Holds registered commands.
+	 *
+	 * Array structure:
+	 * array(
+	 *     'namespace' => array(
+	 *         'command' => 'handler',
+	 *         // ...
+	 *     ),
+	 *     // ...
+	 * )
+	 *
+	 * @var array
+	 */
+	private static $commands = array();
+
+	/**
+	 * Constructor. Hooks into cli_init.
+	 */
+	public function __construct() {
+		add_action( 'cli_init', array( $this, 'register_commands' ) );
+	}
+
+	/**
+	 * Validates that a given value is a non-empty string.
+	 *
+	 * @param mixed  $value The value to validate.
+	 * @param string $field The field name (used for error messages).
+	 *
+	 * @return true|\WP_Error True if valid, or WP_Error on failure.
+	 */
+	private static function validate_required_string( $value, $field ) {
+		if ( ! is_string( $value ) || empty( $value ) ) {
+			return new \WP_Error(
+				'nfd_cli_error',
+				sprintf(
+					/* translators: %s is the name of the field that is invalid (e.g., 'namespace', 'command', or 'handler'). */
+					__( 'Newfold CLI: Invalid %s provided to NFD_WPCLI::add_command().', 'wp-module-performance' ),
+					$field
+				)
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Registers a WP-CLI command under "wp nfd".
+	 *
+	 * @param string $cmd_namespace The command namespace (e.g., "performance").
+	 * @param string $command       The command string.
+	 * @param string $handler       The handler class that implements the command.
+	 *
+	 * @return true|\WP_Error True on success, or WP_Error on failure.
+	 */
+	public static function add_command( $cmd_namespace, $command, $handler ) {
+		$error = self::validate_required_string( $cmd_namespace, 'namespace' );
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		$error = self::validate_required_string( $command, 'command' );
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		$error = self::validate_required_string( $handler, 'handler' );
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		if ( ! class_exists( $handler ) ) {
+			return new \WP_Error(
+				'nfd_cli_error',
+				sprintf(
+					/* translators: %s is the name of the handler class. */
+					__( 'Newfold CLI: The handler class %s does not exist.', 'wp-module-performance' ),
+					$handler
+				)
+			);
+		}
+
+		if ( ! isset( self::$commands[ $cmd_namespace ] ) ) {
+			self::$commands[ $cmd_namespace ] = array();
+		}
+
+		self::$commands[ $cmd_namespace ][ $command ] = $handler;
+
+		return true;
+	}
+
+	/**
+	 * Hooks into WP-CLI and registers all commands.
+	 *
+	 * @return void
+	 */
+	public function register_commands() {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		foreach ( self::$commands as $cmd_namespace => $commands ) {
+			foreach ( $commands as $command => $handler ) {
+				WP_CLI::add_command( "nfd {$cmd_namespace} {$command}", $handler );
+			}
+		}
+	}
+
+	/**
+	 * Outputs a warning message with "Newfold CLI:" prefix.
+	 *
+	 * @param string $message Message to output.
+	 *
+	 * @return void
+	 */
+	public static function warning( $message ) {
+		WP_CLI::warning( 'Newfold CLI: ' . $message );
+	}
+
+	/**
+	 * Outputs an error message with "Newfold CLI:" prefix.
+	 *
+	 * @param string $message Message to output.
+	 *
+	 * @return void
+	 */
+	public static function error( $message ) {
+		WP_CLI::error( 'Newfold CLI: ' . $message );
+	}
+
+	/**
+	 * Outputs a success message with "Newfold CLI:" prefix.
+	 *
+	 * @param string $message Message to output.
+	 *
+	 * @return void
+	 */
+	public static function success( $message ) {
+		WP_CLI::success( 'Newfold CLI: ' . $message );
+	}
+}

--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -79,6 +79,7 @@ class Performance {
 
 		$cacheManager = new CacheManager( $container );
 		$cachePurger  = new CachePurgingService( $cacheManager->getInstances() );
+		new PerformanceWPCLI();
 		new Constants( $container );
 		new ImageManager( $container );
 		new HealthChecks( $container );

--- a/includes/PerformanceWPCLI.php
+++ b/includes/PerformanceWPCLI.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Performance;
+
+use NewfoldLabs\WP\Module\Performance\Images\WPCLI\ImageCommandHandler;
+
+/**
+ * Manages all "wp nfd performance" WP-CLI commands.
+ */
+class PerformanceWPCLI {
+	/**
+	 * Command namespace.
+	 *
+	 * @var string
+	 */
+	private static $cmd_namespace = 'performance';
+
+	/**
+	 * List of performance-related WP-CLI commands.
+	 *
+	 * @var array
+	 */
+	private static $commands = array(
+		'images' => ImageCommandHandler::class,
+	);
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		foreach ( self::$commands as $command => $handler ) {
+			if ( class_exists( $handler ) ) {
+				NFD_WPCLI::add_command( self::$cmd_namespace, $command, $handler );
+			}
+		}
+
+		new NFD_WPCLI();
+	}
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces WP-CLI commands for managing Image Optimization settings, giving us more control over toggling features via the CLI.

It also adds a new NFD_WPCLI class, which serves as a centralized way to register commands under the nfd namespace. This will act as Newfold’s standardized layer for adding commands to WP-CLI programmatically.

Might be worth discussing how we can standardize NFD_WPCLI across other modules.

### Available Commands

Each command follows this structure: 
```bash
wp nfd performance images <command> <on|off>
```

#### Bulk Optimization
Enable or disable bulk optimization for media images.
```bash
wp nfd performance images bulk_optimization on
wp nfd performance images bulk_optimization off
```

#### Lazy Loading
Control lazy loading for images.
```bash
wp nfd performance images lazy_loading on
wp nfd performance images lazy_loading off
```

#### Auto-Optimize Uploaded Images
Automatically optimize images upon upload.
```bash
wp nfd performance images auto_optimize on
wp nfd performance images auto_optimize off
```

#### Auto-Delete Original Images
Remove the original image after optimization.
```bash
wp nfd performance images auto_delete on
wp nfd performance images auto_delete off
```

#### WebP Preference
Prioritize WebP images when an optimized version is available.
```bash
wp nfd performance images webp_preference on
wp nfd performance images webp_preference off
```

#### Toggle All Settings
Enable or disable all image optimization settings at once.
```bash
wp nfd performance images all on
wp nfd performance images all off
```

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->