### PR TITLE
Add PHPCS check for text domain, fix existing incorrect text domains

### DIFF
--- a/includes/HealthChecks/PersistentObjectCacheHealthCheck.php
+++ b/includes/HealthChecks/PersistentObjectCacheHealthCheck.php
@@ -19,7 +19,7 @@ class PersistentObjectCacheHealthCheck extends HealthCheck {
 			'<a href="%1$s" target="_blank" rel="noopener">%2$s</a><span class="screen-reader-text"> (%3$s)</span><span aria-hidden="true" class="dashicons dashicons-external"></span>',
 			'https://www.bluehost.com/help/article/object-caching',
 			esc_html__( 'Learn more about object caching', 'wp-module-performance' ),
-			__( 'opens in a new tab', 'newfold-module-performance' )
+			__( 'opens in a new tab', 'wp-module-performance' )
 		);
 	}
 

--- a/includes/Performance.php
+++ b/includes/Performance.php
@@ -256,14 +256,14 @@ class Performance {
 			$wp_admin_bar->add_node(
 				array(
 					'id'    => 'nfd_purge_menu',
-					'title' => __( 'Caching', 'newfold-module-performance' ),
+					'title' => __( 'Caching', 'wp-module-performance' ),
 				)
 			);
 
 			$wp_admin_bar->add_node(
 				array(
 					'id'     => 'nfd_purge_menu-purge_all',
-					'title'  => __( 'Purge All', 'newfold-module-performance' ),
+					'title'  => __( 'Purge All', 'wp-module-performance' ),
 					'parent' => 'nfd_purge_menu',
 					'href'   => add_query_arg( array( self::PURGE_ALL => true ) ),
 				)
@@ -273,7 +273,7 @@ class Performance {
 				$wp_admin_bar->add_node(
 					array(
 						'id'     => 'nfd_purge_menu-purge_single',
-						'title'  => __( 'Purge This Page', 'newfold-module-performance' ),
+						'title'  => __( 'Purge This Page', 'wp-module-performance' ),
 						'parent' => 'nfd_purge_menu',
 						'href'   => add_query_arg( array( self::PURGE_URL => true ) ),
 					)
@@ -284,7 +284,7 @@ class Performance {
 			$wp_admin_bar->add_node(
 				array(
 					'id'     => 'nfd_purge_menu-cache_settings',
-					'title'  => __( 'Cache Settings', 'newfold-module-performance' ),
+					'title'  => __( 'Cache Settings', 'wp-module-performance' ),
 					'parent' => 'nfd_purge_menu',
 					'href'   => admin_url( "admin.php?page=$brand#/performance" ),
 				)
@@ -297,8 +297,8 @@ class Performance {
 	public function add_sub_menu_page() {
 		$brand = $this->container->get( 'plugin' )['id'];
 		add_management_page(
-			__( 'Performance', 'newfold-performance-module' ),
-			__( 'Performance', 'newfold-performance-module' ),
+			__( 'Performance', 'wp-module-performance' ),
+			__( 'Performance', 'wp-module-performance' ),
 			'manage_options',
 			admin_url( "admin.php?page=$brand#/performance" ),
 			null,

--- a/includes/RestApi/JetpackController.php
+++ b/includes/RestApi/JetpackController.php
@@ -64,7 +64,7 @@ class JetpackController {
 				return new \WP_REST_Response(
 					array(
 						'success' => false,
-						'error'   => __( "The parameter 'field' is missing or invalid.", 'newfold-performance-module' ),
+						'error'   => __( "The parameter 'field' is missing or invalid.", 'wp-module-performance' ),
 					),
 					400
 				);
@@ -76,7 +76,7 @@ class JetpackController {
 				return new \WP_REST_Response(
 					array(
 						'success' => false,
-						'error'   => __( "The fields 'id' and 'value' are required.", 'newfold-performance-module' ),
+						'error'   => __( "The fields 'id' and 'value' are required.", 'wp-module-performance' ),
 					),
 					400
 				);
@@ -100,7 +100,7 @@ class JetpackController {
 				return new \WP_REST_Response(
 					array(
 						'success' => false,
-						'error'   => __( 'An error occurred while updating the option.', 'newfold-performance-module' ),
+						'error'   => __( 'An error occurred while updating the option.', 'wp-module-performance' ),
 					),
 					500
 				);
@@ -120,7 +120,7 @@ class JetpackController {
 			return new \WP_REST_Response(
 				array(
 					'success' => false,
-					'error'   => __( 'An error occurred while updating the option.', 'newfold-performance-module' ) . $e->getMessage(),
+					'error'   => __( 'An error occurred while updating the option.', 'wp-module-performance' ) . $e->getMessage(),
 				),
 				500
 			);

--- a/includes/RestApi/SettingsController.php
+++ b/includes/RestApi/SettingsController.php
@@ -59,7 +59,7 @@ class SettingsController {
 				return new \WP_REST_Response(
 					array(
 						'success' => false,
-						'error'   => __( "The parameter 'field' is missing or invalid.", 'newfold-performance-module' ),
+						'error'   => __( "The parameter 'field' is missing or invalid.", 'wp-module-performance' ),
 					),
 					400
 				);
@@ -71,7 +71,7 @@ class SettingsController {
 				return new \WP_REST_Response(
 					array(
 						'success' => false,
-						'error'   => __( "The fields 'id' and 'value' are required.", 'newfold-performance-module' ),
+						'error'   => __( "The fields 'id' and 'value' are required.", 'wp-module-performance' ),
 					),
 					400
 				);
@@ -90,7 +90,7 @@ class SettingsController {
 				return new \WP_REST_Response(
 					array(
 						'success' => false,
-						'error'   => __( 'An error occurred while updating the option.', 'newfold-performance-module' ),
+						'error'   => __( 'An error occurred while updating the option.', 'wp-module-performance' ),
 					),
 					500
 				);
@@ -110,7 +110,7 @@ class SettingsController {
 			return new \WP_REST_Response(
 				array(
 					'success' => false,
-					'error'   => __( 'An error occurred while updating the option.', 'newfold-performance-module' ) . $e->getMessage(),
+					'error'   => __( 'An error occurred while updating the option.', 'wp-module-performance' ) . $e->getMessage(),
 				),
 				500
 			);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -45,7 +45,7 @@ function getCacheLevelDropdown() { // phpcs:ignore WordPress.NamingConventions.V
 	$currentCacheLevel = getCacheLevel();
 
 	$name  = CacheManager::OPTION_CACHE_LEVEL;
-	$label = __( 'Cache Level', 'newfold-performance-module' );
+	$label = __( 'Cache Level', 'wp-module-performance' );
 	?>
 	<select name="<?php echo esc_attr( $name ); ?>" aria-label="<?php echo esc_attr( $label ); ?>">
 		<?php foreach ( $cacheLevels as $cacheLevel => $optionLabel ) : ?>
@@ -72,7 +72,7 @@ function getSkip404Option() { // phpcs:ignore WordPress.NamingConventions.ValidF
 function getSkip404InputField() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	$name  = Skip404::OPTION_SKIP_404;
 	$value = getSkip404Option();
-	$label = __( 'Skip WordPress 404 Handling for Static Files', 'newfold-performance-module' );
+	$label = __( 'Skip WordPress 404 Handling for Static Files', 'wp-module-performance' );
 	?>
 	<input
 		type="checkbox"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,4 +9,9 @@
         <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
         <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
     </rule>
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array" value="wp-module-performance" />
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
Adds a check for the text domain to PHPCS, fixes incorrect text domains.

Also added everyone as a reviewer just in case anyone wants to use this opportunity to argue for a different text domain, such as `newfold-module-performance`.