### PR TITLE
Fix on_update_option to purge page caches only, not object cache

### DIFF
--- a/includes/Cache/CachePurgingService.php
+++ b/includes/Cache/CachePurgingService.php
@@ -210,7 +210,7 @@ class CachePurgingService {
 	}
 
 	/**
-	 * Purge all caches when an option is updated.
+	 * Purge page caches when an option is updated. Does not flush object cache (Redis).
 	 *
 	 * @param  string $option    Option name.
 	 * @param  mixed  $oldValue  Old option value.
@@ -322,7 +322,7 @@ class CachePurgingService {
 			}
 		}
 
-		$this->purge_all();
+		$this->purge_page_caches();
 
 		return true;
 	}


### PR DESCRIPTION
The on_update_option handler was calling purge_all() which flushes both page caches and the Redis object cache. This caused SSO tokens stored as transients in Redis to be destroyed whenever a non-exempt option was updated — for example during plugin upgrade routines that run on the same request as an SSO login.

Changed to purge_page_caches() which only clears file-based page cache. Option updates do not require an object cache flush since WordPress already invalidates the specific option key in the object cache internally.

The better solution would be https://newfold.atlassian.net/browse/HOST-7828 but this might take time.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->