### PR TITLE
chore(i18n): align Composer i18n scripts with WP-CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,13 @@
     "scripts-descriptions": {
         "cs-fix": "Automatically fix coding standards issues where possible.",
         "cs-lint": "Check files against coding standards.",
-        "i18n": "Generate files for translation.",
+        "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+        "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+        "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs.",
+        "i18n-json": "Remove stale JSON catalogs, then generate JED JSON from PO files using wp i18n make-json.",
+        "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+        "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+        "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
         "test": "Run tests.",
         "test-coverage": "Run tests with coverage, merge coverage and create HTML report."
     },


### PR DESCRIPTION
## Summary
Complete `scripts-descriptions` for all Composer scripts. `make-json` / `make-php` flags were already aligned on `main`.

## Verification
- `composer validate`
- `composer run-script --list`

Made with [Cursor](https://cursor.com)