### PR TITLE
Add `NFD_DISABLE_OBJECT_CACHE_AUTO_MANAGEMENT`

### DIFF
--- a/includes/Cache/Types/ObjectCache.php
+++ b/includes/Cache/Types/ObjectCache.php
@@ -55,6 +55,15 @@ class ObjectCache {
 	const OPTION_ENABLED_PREFERENCE = 'newfold_object_cache_enabled_preference';
 
 	/**
+	 * When true, disables all automatic object-cache.php deletion/replacement from this module
+	 * (plugins_loaded cleanup, reconcile, enable failure cleanup, disable file removal).
+	 *
+	 * Define in wp-config.php before wp-settings.php loads, for example:
+	 * `define( 'NFD_DISABLE_OBJECT_CACHE_AUTO_MANAGEMENT', true );`
+	 */
+	const DISABLE_AUTO_MANAGEMENT_CONSTANT = 'NFD_DISABLE_OBJECT_CACHE_AUTO_MANAGEMENT';
+
+	/**
 	 * Cached wp-config existence check (per request).
 	 *
 	 * @var bool|null
@@ -226,7 +235,8 @@ class ObjectCache {
 			$ping = self::run_connectivity_preflight();
 			if ( true !== $ping ) {
 				if (
-					is_array( $ping )
+					! self::is_object_cache_dropin_auto_management_disabled()
+					&& is_array( $ping )
 					&& isset( $ping['code'] )
 					&& ObjectCacheErrorCodes::REDIS_UNREACHABLE === $ping['code']
 				) {
@@ -346,6 +356,13 @@ class ObjectCache {
 			return array( 'success' => true );
 		}
 
+		if ( self::is_object_cache_dropin_auto_management_disabled() ) {
+			if ( $clear_preference ) {
+				update_option( self::OPTION_ENABLED_PREFERENCE, false );
+			}
+			return array( 'success' => true );
+		}
+
 		// Flush Redis and clear options cache while our drop-in is still active, then remove the file.
 		self::flush_object_cache();
 		self::clear_options_object_cache();
@@ -415,6 +432,10 @@ class ObjectCache {
 	 * @return void
 	 */
 	public static function maybe_restore_dropin() {
+		if ( self::is_object_cache_dropin_auto_management_disabled() ) {
+			return;
+		}
+
 		if ( ! self::is_preference_enabled() ) {
 			return;
 		}
@@ -716,9 +737,22 @@ class ObjectCache {
 	 * a constant (e.g. WP_REDIS_PREFIX from WP_CACHE_KEY_SALT or env). Also clears the enabled preference.
 	 * Checks for the drop-in file first so we skip wp-config read/parse on most requests (no drop-in).
 	 *
+	 * When the user has not turned host-managed object cache on (stored preference is not true), does
+	 * nothing: the UI can show "off" while the option is still unset, and the Redis Object Cache plugin
+	 * uses the same drop-in header fingerprint as ours.
+	 *
+	 * Opt out entirely with {@see self::DISABLE_AUTO_MANAGEMENT_CONSTANT}.
+	 *
 	 * @return void
 	 */
 	public static function maybe_remove_dropin_if_unavailable() {
+		if ( self::is_object_cache_dropin_auto_management_disabled() ) {
+			return;
+		}
+		if ( ! self::is_preference_enabled() ) {
+			return;
+		}
+
 		$path = self::get_drop_in_path();
 		if ( ! file_exists( $path ) || ! self::is_our_drop_in( $path ) ) {
 			return;
@@ -730,6 +764,33 @@ class ObjectCache {
 	}
 
 	/**
+	 * Whether automatic drop-in install/remove/reconcile is disabled via wp-config constant.
+	 *
+	 * @see self::DISABLE_AUTO_MANAGEMENT_CONSTANT
+	 *
+	 * @return bool
+	 */
+	public static function is_object_cache_dropin_auto_management_disabled() {
+		$constant_name = self::DISABLE_AUTO_MANAGEMENT_CONSTANT;
+
+		return defined( $constant_name ) && self::normalize_to_bool( constant( $constant_name ) );
+	}
+
+	/**
+	 * Coerce a value to boolean (wp-config defines may use strings).
+	 *
+	 * @param mixed $value Raw value.
+	 * @return bool
+	 */
+	private static function normalize_to_bool( $value ) {
+		if ( function_exists( 'wp_validate_boolean' ) ) {
+			return wp_validate_boolean( $value );
+		}
+
+		return (bool) filter_var( $value, FILTER_VALIDATE_BOOLEAN );
+	}
+
+	/**
 	 * Delete our object-cache.php and set the enabled preference to false.
 	 *
 	 * Does not call wp_cache_flush(); used when Redis is unreachable or wp-config no longer has creds
@@ -738,6 +799,9 @@ class ObjectCache {
 	 * @return bool True if the file was ours and was removed.
 	 */
 	private static function remove_our_dropin_file_and_disable_preference(): bool {
+		if ( self::is_object_cache_dropin_auto_management_disabled() ) {
+			return false;
+		}
 		if ( ! self::delete_our_drop_in_file_if_ours() ) {
 			return false;
 		}
@@ -784,6 +848,10 @@ class ObjectCache {
 	 * @return void
 	 */
 	public static function reconcile_non_ours_dropin() {
+		if ( self::is_object_cache_dropin_auto_management_disabled() ) {
+			return;
+		}
+
 		$path = self::get_drop_in_path();
 		if ( ! file_exists( $path ) || self::is_our_drop_in( $path ) ) {
 			return;

--- a/tests/phpunit/includes/ObjectCacheTest.php
+++ b/tests/phpunit/includes/ObjectCacheTest.php
@@ -24,6 +24,13 @@ class ObjectCacheTest extends TestCase {
 		if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 			define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/wp-content-performance-test' );
 		}
+		if ( ! is_dir( WP_CONTENT_DIR ) ) {
+			mkdir( WP_CONTENT_DIR, 0777, true );
+		}
+		$dropin = WP_CONTENT_DIR . '/object-cache.php';
+		if ( is_file( $dropin ) ) {
+			unlink( $dropin );
+		}
 	}
 
 	/**
@@ -187,5 +194,57 @@ class ObjectCacheTest extends TestCase {
 
 		ObjectCache::reconcile_non_ours_dropin();
 		$this->assertTrue( true, 'Reconcile with sentinel (preference not set) and Redis not available should leave file alone.' );
+	}
+
+	/**
+	 * When preference is not on (false), maybe_remove_dropin_if_unavailable must not delete the drop-in.
+	 */
+	public function test_maybe_remove_dropin_if_unavailable_respects_preference_disabled() {
+		$path = WP_CONTENT_DIR . '/object-cache.php';
+		file_put_contents(
+			$path,
+			"<?php\n/**\n * Plugin Name: " . ObjectCache::DROPIN_HEADER_IDENTIFIER . "\n */\n"
+		);
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( ObjectCache::OPTION_ENABLED_PREFERENCE, null )
+			->andReturn( false );
+
+		Patchwork\redefine(
+			array( ObjectCache::class, 'is_configured_in_wp_config' ),
+			function () {
+				return false;
+			}
+		);
+
+		ObjectCache::maybe_remove_dropin_if_unavailable();
+
+		$this->assertFileExists( $path );
+	}
+
+	/**
+	 * When the preference option was never saved (null), UI can show "off" but maybe_remove must not delete.
+	 */
+	public function test_maybe_remove_dropin_if_unavailable_respects_preference_unset() {
+		$path = WP_CONTENT_DIR . '/object-cache.php';
+		file_put_contents(
+			$path,
+			"<?php\n/**\n * Plugin Name: " . ObjectCache::DROPIN_HEADER_IDENTIFIER . "\n */\n"
+		);
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( ObjectCache::OPTION_ENABLED_PREFERENCE, null )
+			->andReturn( null );
+
+		Patchwork\redefine(
+			array( ObjectCache::class, 'is_configured_in_wp_config' ),
+			function () {
+				return false;
+			}
+		);
+
+		ObjectCache::maybe_remove_dropin_if_unavailable();
+
+		$this->assertFileExists( $path );
 	}
 }


### PR DESCRIPTION
…T_CACHE_AUTO_MANAGEMENT (PRESS0-4268)

- Only auto-remove object-cache.php on plugins_loaded when the stored preference is on, so the UI can show off while the option is unset and the same drop-in header as other plugins is not deleted.
- Add wp-config constant NFD_DISABLE_OBJECT_CACHE_AUTO_MANAGEMENT to skip all module-driven drop-in install/remove/reconcile.
- Coerce the constant to bool via wp_validate_boolean or filter_var.
- Add and update PHPUnit coverage for the new behavior.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->