### PR TITLE
PRESS0-4295: object cache UX fixes

### DIFF
--- a/includes/Cache/Types/ObjectCache.php
+++ b/includes/Cache/Types/ObjectCache.php
@@ -219,7 +219,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::DROPIN_OVERWRITTEN,
-				'message' => __( 'Another object cache drop-in is active. Disable it in the other plugin first.', 'wp-module-performance' ),
+				'message' => __( "Another plugin's object cache is active. Disable it in that plugin first.", 'wp-module-performance' ),
 			);
 		}
 
@@ -227,7 +227,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::PHPREDIS_MISSING,
-				'message' => __( 'The PHP Redis extension (phpredis) is required before object cache can be enabled.', 'wp-module-performance' ),
+				'message' => __( 'Object caching is not supported on this server.', 'wp-module-performance' ),
 			);
 		}
 
@@ -260,7 +260,7 @@ class ObjectCache {
 				return array(
 					'success' => false,
 					'code'    => ObjectCacheErrorCodes::CREDENTIALS_PENDING_RELOAD,
-					'message' => __( 'Redis credentials are being applied. Please wait a few seconds and try again.', 'wp-module-performance' ),
+					'message' => __( 'Setting up object cache. Please wait a few seconds and try again.', 'wp-module-performance' ),
 				);
 			}
 		}
@@ -284,7 +284,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::DOWNLOAD_FAILED,
-				'message' => $response->get_error_message(),
+				'message' => __( 'Could not download object cache files. Please try again later.', 'wp-module-performance' ),
 			);
 		}
 
@@ -293,11 +293,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::DOWNLOAD_FAILED,
-				'message' => sprintf(
-					/* translators: %d: HTTP status code */
-					__( 'Failed to download object cache (HTTP %d).', 'wp-module-performance' ),
-					$code
-				),
+				'message' => __( 'Could not download object cache files. Please try again later.', 'wp-module-performance' ),
 			);
 		}
 
@@ -306,7 +302,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::INVALID_DROPIN,
-				'message' => __( 'Downloaded content is not valid. Please try again.', 'wp-module-performance' ),
+				'message' => __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
 			);
 		}
 
@@ -330,7 +326,7 @@ class ObjectCache {
 		return array(
 			'success' => false,
 			'code'    => ObjectCacheErrorCodes::WRITE_FAILED,
-			'message' => __( 'Could not write object-cache.php. Check file permissions.', 'wp-module-performance' ),
+			'message' => __( 'Could not save object cache file. Check file permissions or contact support.', 'wp-module-performance' ),
 		);
 	}
 
@@ -395,7 +391,7 @@ class ObjectCache {
 
 		return array(
 			'success' => false,
-			'message' => __( 'Could not remove object-cache.php. Check file permissions.', 'wp-module-performance' ),
+			'message' => __( 'Could not disable object cache. Check file permissions or contact support.', 'wp-module-performance' ),
 		);
 	}
 
@@ -490,7 +486,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::CREDENTIALS_MISSING,
-				'message' => __( 'Redis credentials are not present in wp-config.php.', 'wp-module-performance' ),
+				'message' => __( 'Object cache is not configured yet.', 'wp-module-performance' ),
 			);
 		}
 
@@ -501,7 +497,7 @@ class ObjectCache {
 			return array(
 				'success' => false,
 				'code'    => ObjectCacheErrorCodes::REDIS_UNREACHABLE,
-				'message' => isset( $ping['message'] ) ? (string) $ping['message'] : __( 'Could not connect to Redis.', 'wp-module-performance' ),
+				'message' => __( 'Could not connect to the object cache. Please try again later.', 'wp-module-performance' ),
 			);
 		}
 
@@ -702,12 +698,12 @@ class ObjectCache {
 		}
 
 		$known = array(
-			ObjectCacheErrorCodes::HIIVE_NOT_CONNECTED     => __( 'This site is not connected to Hiive, so Redis credentials cannot be provisioned automatically.', 'wp-module-performance' ),
-			ObjectCacheErrorCodes::HUAPI_TOKEN_UNAVAILABLE => __( 'HUAPI token is not available yet. Try again in a few minutes or contact support.', 'wp-module-performance' ),
-			ObjectCacheErrorCodes::HAL_SITE_ID_MISSING     => __( 'Hosting site id is not available yet. Try again in a few minutes or contact support.', 'wp-module-performance' ),
-			ObjectCacheErrorCodes::REDIS_UNREACHABLE       => __( 'Could not connect to Redis.', 'wp-module-performance' ),
-			'nfd_hiive_error'                              => __( 'Could not reach Hiive to provision Redis credentials.', 'wp-module-performance' ),
-			'nfd_hosting_uapi_error'                       => __( 'Hosting API could not enable Redis for this site.', 'wp-module-performance' ),
+			ObjectCacheErrorCodes::HIIVE_NOT_CONNECTED     => __( 'Object cache cannot be enabled automatically right now. Please contact support.', 'wp-module-performance' ),
+			ObjectCacheErrorCodes::HUAPI_TOKEN_UNAVAILABLE => __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			ObjectCacheErrorCodes::HAL_SITE_ID_MISSING     => __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			ObjectCacheErrorCodes::REDIS_UNREACHABLE       => __( 'Could not connect to the object cache. Please try again later.', 'wp-module-performance' ),
+			'nfd_hiive_error'                              => __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			'nfd_hosting_uapi_error'                       => __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
 		);
 
 		if ( isset( $known[ $code ] ) ) {

--- a/includes/Cache/Types/ObjectCachePreflight.php
+++ b/includes/Cache/Types/ObjectCachePreflight.php
@@ -37,20 +37,19 @@ final class ObjectCachePreflight {
 		if ( ! $extension_loaded ) {
 			$ping_ok = false;
 			$code    = ObjectCacheErrorCodes::PHPREDIS_MISSING;
-			$message = __( 'The PHP Redis extension (phpredis) is not loaded.', 'wp-module-performance' );
+			$message = __( 'Object caching is not supported on this server.', 'wp-module-performance' );
 		} elseif ( ! $configured ) {
 			$ping_ok = false;
 			// Same order as RedisCredentialsProvisioner::provision_enable_redis_via_hosting_api() before HTTP.
 			if ( ! $hiive_connected ) {
 				$code    = ObjectCacheErrorCodes::HIIVE_NOT_CONNECTED;
 				$message = __(
-					'This site is not connected to Hiive, so Redis credentials cannot be provisioned automatically.',
+					'Object cache cannot be enabled automatically right now.',
 					'wp-module-performance'
 				);
-			} else {
-				$code    = ObjectCacheErrorCodes::CREDENTIALS_MISSING;
-				$message = __( 'Redis credentials are not present in wp-config.php.', 'wp-module-performance' );
 			}
+			// When wp-config lacks creds but Hiive is connected, enabling will provision creds via the
+			// hosting API — that's a normal "ready to enable" state, not an error worth surfacing in the UI.
 		} elseif ( $include_live_ping ) {
 			// Important: bootstrap WP_REDIS_* from wp-config when constants exist in file but aren't defined() yet.
 			ObjectCache::bootstrap_redis_connection_constants_for_preflight();
@@ -59,7 +58,7 @@ final class ObjectCachePreflight {
 			$ping_ok = (bool) ( $ping['ok'] ?? false );
 			if ( ! $ping_ok ) {
 				$code    = ObjectCacheErrorCodes::REDIS_UNREACHABLE;
-				$message = isset( $ping['message'] ) ? (string) $ping['message'] : __( 'Could not connect to Redis.', 'wp-module-performance' );
+				$message = __( 'Could not connect to the object cache.', 'wp-module-performance' );
 			}
 		}
 

--- a/includes/Helpers/HiiveHelper.php
+++ b/includes/Helpers/HiiveHelper.php
@@ -65,7 +65,7 @@ class HiiveHelper {
 		if ( ! HiiveConnection::is_connected() ) {
 			return new \WP_Error(
 				'nfd_hiive_error',
-				__( 'Failed to connect to Hiive API.', 'wp-module-performance' )
+				__( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' )
 			);
 		}
 
@@ -98,11 +98,7 @@ class HiiveHelper {
 		if ( $code < 200 || $code >= 300 ) {
 			return new \WP_Error(
 				'nfd_hiive_error',
-				sprintf(
-					/* translators: %d: HTTP status code */
-					__( 'Hiive API returned HTTP %d.', 'wp-module-performance' ),
-					$code
-				),
+				__( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
 				array(
 					'status' => $code,
 					'body'   => wp_remote_retrieve_body( $response ),

--- a/includes/Helpers/HostingUapiClient.php
+++ b/includes/Helpers/HostingUapiClient.php
@@ -20,7 +20,7 @@ final class HostingUapiClient {
 		$site_id   = (string) $site_id;
 
 		if ( '' === $huapi_jwt || '' === $site_id ) {
-			return new \WP_Error( 'nfd_hosting_uapi_error', __( 'Missing HUAPI credentials.', 'wp-module-performance' ) );
+			return new \WP_Error( 'nfd_hosting_uapi_error', __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ) );
 		}
 
 		$base = SiteApisConfig::hosting_uapi_base_url();
@@ -61,12 +61,7 @@ final class HostingUapiClient {
 
 			$err = new \WP_Error(
 				'nfd_hosting_uapi_error',
-				sprintf(
-					/* translators: 1: HTTP status code, 2: response snippet */
-					__( 'Hosting API returned HTTP %1$s: %2$s', 'wp-module-performance' ),
-					(string) $code,
-					self::snippet( $raw )
-				),
+				__( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
 				array(
 					'status'         => $code,
 					'body'           => $raw,

--- a/includes/Helpers/RedisCredentialsProvisioner.php
+++ b/includes/Helpers/RedisCredentialsProvisioner.php
@@ -19,7 +19,7 @@ final class RedisCredentialsProvisioner {
 		if ( ! HiiveConnection::is_connected() ) {
 			return new \WP_Error(
 				ObjectCacheErrorCodes::HIIVE_NOT_CONNECTED,
-				__( 'This site is not connected to Hiive, so Redis credentials cannot be provisioned automatically.', 'wp-module-performance' )
+				__( 'Object cache cannot be enabled automatically right now. Please contact support.', 'wp-module-performance' )
 			);
 		}
 
@@ -34,7 +34,7 @@ final class RedisCredentialsProvisioner {
 		if ( ! is_array( $data ) ) {
 			return new \WP_Error(
 				ObjectCacheErrorCodes::HUAPI_ERROR,
-				__( 'Unexpected response while reading customer data from Hiive.', 'wp-module-performance' )
+				__( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' )
 			);
 		}
 
@@ -44,14 +44,14 @@ final class RedisCredentialsProvisioner {
 		if ( '' === $token ) {
 			return new \WP_Error(
 				ObjectCacheErrorCodes::HUAPI_TOKEN_UNAVAILABLE,
-				__( 'HUAPI token is not available yet. Try again in a few minutes or contact support.', 'wp-module-performance' )
+				__( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' )
 			);
 		}
 
 		if ( '' === $site_id || ! ctype_digit( $site_id ) ) {
 			return new \WP_Error(
 				ObjectCacheErrorCodes::HAL_SITE_ID_MISSING,
-				__( 'Hosting site id is not available yet. Try again in a few minutes or contact support.', 'wp-module-performance' )
+				__( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' )
 			);
 		}
 

--- a/includes/RestApi/CacheController.php
+++ b/includes/RestApi/CacheController.php
@@ -111,11 +111,13 @@ class CacheController {
 				if ( $cache_level <= 0 ) {
 					ObjectCache::disable();
 				}
-				$response = array( 'result' => true );
-				if ( $cache_level <= 0 ) {
-					$response['objectCache'] = ObjectCache::get_state();
-				}
-				return new \WP_REST_Response( $response, 200 );
+				return new \WP_REST_Response(
+					array(
+						'result'      => true,
+						'objectCache' => ObjectCache::get_state(),
+					),
+					200
+				);
 			}
 			return new \WP_REST_Response( array( 'result' => false ), 400 );
 		}

--- a/src/sections/CacheSettings/index.js
+++ b/src/sections/CacheSettings/index.js
@@ -51,7 +51,7 @@ const CacheSettings = () => {
 				setUpdating( false );
 				setCacheLevel( selectedLevel );
 				dispatchSetCacheLevel( selectedLevel );
-				if ( selectedLevel <= 0 && response?.objectCache ) {
+				if ( response?.objectCache ) {
 					dispatchSetObjectCache( response.objectCache );
 				}
 			} )

--- a/src/sections/ObjectCache/getObjectCacheText.js
+++ b/src/sections/ObjectCache/getObjectCacheText.js
@@ -20,43 +20,43 @@ const getObjectCacheText = () => ( {
 				'wp-module-performance'
 			),
 			phpredis_missing: __(
-				'PHP Redis (phpredis) is not available on this server. Ask your host to enable the Redis extension for your PHP version.',
+				'Object caching is not supported on this server. Please contact your hosting provider for help.',
 				'wp-module-performance'
 			),
 			credentials_missing: __(
-				'Redis credentials are not present in wp-config.php yet.',
+				'Object cache is not configured yet. Please try again in a moment.',
 				'wp-module-performance'
 			),
 			credentials_pending_reload: __(
-				'Redis credentials are being applied. We will retry automatically in a few seconds.',
+				'Setting up object cache. We will retry automatically in a few seconds.',
 				'wp-module-performance'
 			),
 			hiive_not_connected: __(
-				'This site is not connected to Hiive, so Redis credentials cannot be provisioned automatically.',
+				'Object cache cannot be enabled automatically right now. Please contact support.',
 				'wp-module-performance'
 			),
 			huapi_token_unavailable: __(
-				'Hosting token is not available yet. Please try again shortly or contact support.',
+				'Could not enable object cache right now. Please try again later.',
 				'wp-module-performance'
 			),
 			hal_site_id_missing: __(
-				'Hosting site id is not available yet. Please try again shortly or contact support.',
+				'Could not enable object cache right now. Please try again later.',
 				'wp-module-performance'
 			),
-			redis_unreachable: __( 'Could not connect to Redis with the current credentials.', 'wp-module-performance' ),
-			redisServiceInactive: __( 'Redis service is not active on the server yet.', 'wp-module-performance' ),
+			redis_unreachable: __( 'Could not connect to the object cache. Please try again later.', 'wp-module-performance' ),
+			redisServiceInactive: __( 'Object cache is not ready on this server yet. Please try again later.', 'wp-module-performance' ),
 			phpVersionUnsupported: __(
-				'Your PHP version does not meet requirements for Redis on this hosting environment.',
+				'Object caching is not supported on this server. Please contact your hosting provider for help.',
 				'wp-module-performance'
 			),
-			dropInUnavailable: __( 'Hosting reports the Redis drop-in is not available yet.', 'wp-module-performance' ),
-			wordpressNotFound: __( 'Hosting could not locate WordPress for this site.', 'wp-module-performance' ),
-			nfd_hiive_error: __( 'Could not reach Hiive to provision Redis credentials.', 'wp-module-performance' ),
-			nfd_hosting_uapi_error: __( 'Hosting API could not enable Redis for this site.', 'wp-module-performance' ),
-			huapi_error: __( 'Hosting API returned an unexpected error while enabling Redis.', 'wp-module-performance' ),
-			download_failed: __( 'Failed to download the Redis object cache drop-in.', 'wp-module-performance' ),
-			invalid_dropin: __( 'Downloaded drop-in content was invalid.', 'wp-module-performance' ),
-			write_failed: __( 'Could not write object-cache.php. Check file permissions.', 'wp-module-performance' ),
+			dropInUnavailable: __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			wordpressNotFound: __( 'Could not enable object cache right now. Please contact support.', 'wp-module-performance' ),
+			nfd_hiive_error: __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			nfd_hosting_uapi_error: __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			huapi_error: __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			download_failed: __( 'Could not download object cache files. Please try again later.', 'wp-module-performance' ),
+			invalid_dropin: __( 'Could not enable object cache right now. Please try again later.', 'wp-module-performance' ),
+			write_failed: __( 'Could not save object cache file. Check file permissions or contact support.', 'wp-module-performance' ),
 		};
 
 		if ( code && map[ code ] ) {

--- a/src/sections/ObjectCache/index.js
+++ b/src/sections/ObjectCache/index.js
@@ -38,16 +38,24 @@ const ObjectCache = () => {
 	const retryTimerRef = useRef( null );
 	const retryAttemptsRef = useRef( 0 );
 
-	const { pushNotification } = useDispatch( STORE_NAME );
+	const { pushNotification, setObjectCache: dispatchSetObjectCache } = useDispatch( STORE_NAME );
 	const apiUrl = NewfoldRuntime.createApiUrl(
 		'/newfold-performance/v1/cache/settings'
 	);
+
+	// Seed the store from runtime on mount so preflight gating is consistent from the first render.
+	useEffect( () => {
+		const runtimeObjectCache = NewfoldRuntime?.sdk?.cache?.objectCache;
+		if ( runtimeObjectCache && ! storeObjectCache ) {
+			dispatchSetObjectCache( runtimeObjectCache );
+		}
+	}, [] );
 
 	useEffect( () => {
 		setEnabled( runtimeEnabled );
 	}, [ runtimeEnabled ] );
 
-	// When cache level is set to disabled, store receives objectCache state; sync toggle.
+	// When the store updates (cache level change, refetch), sync local toggle to server truth.
 	useEffect( () => {
 		if ( storeObjectCache && typeof storeObjectCache.enabled === 'boolean' ) {
 			setEnabled( storeObjectCache.enabled );
@@ -64,8 +72,11 @@ const ObjectCache = () => {
 
 	const refetchSettings = async () => {
 		const settings = await apiFetch( { url: apiUrl } );
-		if ( settings?.objectCache && 'enabled' in settings.objectCache ) {
-			setEnabled( settings.objectCache.enabled === true );
+		if ( settings?.objectCache ) {
+			dispatchSetObjectCache( settings.objectCache );
+			if ( 'enabled' in settings.objectCache ) {
+				setEnabled( settings.objectCache.enabled === true );
+			}
 		}
 		return settings;
 	};
@@ -193,7 +204,7 @@ const ObjectCache = () => {
 					{ objectCacheOverwrittenNotice }
 				</p>
 			) }
-			{ ! overwritten && preflight?.preflightMessage && (
+			{ ! overwritten && ! isCacheDisabled && preflight?.preflightMessage && (
 				<p className="nfd-mb-4 nfd-text-sm nfd-text-orange-600">{ preflight.preflightMessage }</p>
 			) }
 			<ToggleField

--- a/src/sections/ObjectCache/index.js
+++ b/src/sections/ObjectCache/index.js
@@ -200,12 +200,12 @@ const ObjectCache = () => {
 			description={ objectCacheDescription }
 		>
 			{ overwritten && (
-				<p className="nfd-mb-4 nfd-text-sm nfd-text-orange-600">
+				<p className="nfd-mb-4 nfd-text-sm nfd-text-orange-700">
 					{ objectCacheOverwrittenNotice }
 				</p>
 			) }
 			{ ! overwritten && ! isCacheDisabled && preflight?.preflightMessage && (
-				<p className="nfd-mb-4 nfd-text-sm nfd-text-orange-600">{ preflight.preflightMessage }</p>
+				<p className="nfd-mb-4 nfd-text-sm nfd-text-orange-700">{ preflight.preflightMessage }</p>
 			) }
 			<ToggleField
 				id="object-cache"

--- a/tests/phpunit/includes/ObjectCachePreflightTest.php
+++ b/tests/phpunit/includes/ObjectCachePreflightTest.php
@@ -92,7 +92,7 @@ namespace NewfoldLabs\WP\Module\Performance\Cache {
 			);
 		}
 
-		public function test_preflight_credentials_missing_when_hiive_connected_and_wp_config_has_no_creds() {
+		public function test_preflight_emits_no_error_when_hiive_connected_and_wp_config_has_no_creds() {
 			Patchwork\redefine(
 				'extension_loaded',
 				function ( $ext ) {
@@ -123,11 +123,12 @@ namespace NewfoldLabs\WP\Module\Performance\Cache {
 
 			$snapshot = \NewfoldLabs\WP\Module\Performance\Cache\Types\ObjectCachePreflight::snapshot( false );
 
+			// Hiive is connected and provisioning will run on enable click — this is a
+			// "ready to enable" state, not an error worth surfacing in the UI.
 			$this->assertTrue( $snapshot['hiiveConnected'] );
-			$this->assertSame(
-				\NewfoldLabs\WP\Module\Performance\Cache\Types\ObjectCacheErrorCodes::CREDENTIALS_MISSING,
-				$snapshot['preflightCode']
-			);
+			$this->assertFalse( $snapshot['configuredInWpConfig'] );
+			$this->assertNull( $snapshot['preflightCode'] );
+			$this->assertNull( $snapshot['preflightMessage'] );
 		}
 	}
 }


### PR DESCRIPTION
- soften user-facing error messages so they don't leak Hiive/HUAPI/wp-config/drop-in internals
- hide preflight notice when cache level is disabled (toggle is greyed anyway)
- drop the "object cache is not configured yet" notice when Hiive is connected, since clicking enable will provision creds via the hosting API
- always return objectCache state in the cache-level update response, and always dispatch it client-side, so the store stays in sync after going off then back on
- seed the data store from runtime on mount and dispatch on every refetch so the preflight gate is consistent from the first render

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->