### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to commit translation files on the caller repository.
       pull-requests: write # Required for the reusable workflow to open or update translation pull requests.
+    timeout-minutes: 30
     with:
       text_domain: 'wp-module-performance'
       i18n-script-location: 'npm'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to commit translation files on the caller repository.
+      pull-requests: write # Required for the reusable workflow to open or update translation pull requests.
     with:
       text_domain: 'wp-module-performance'
       i18n-script-location: 'npm'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # No steps use the GitHub token; branch name comes from context and bash only.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Cypress
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required so the reusable workflow can clone private plugin and module repositories via actions/checkout.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -44,6 +44,8 @@ jobs:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required so the reusable workflow can clone private plugin and module repositories via actions/checkout.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -56,6 +58,8 @@ jobs:
     name: Hostgator Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required so the reusable workflow can clone private plugin and module repositories via actions/checkout.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No steps use the GitHub token; branch name comes from context and bash only.
+    timeout-minutes: 10
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the reusable workflow can clone private plugin and module repositories via actions/checkout.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the reusable workflow can clone private plugin and module repositories via actions/checkout.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -60,6 +63,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the reusable workflow can clone private plugin and module repositories via actions/checkout.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Output uses only bash and github.repository context; no GitHub token API calls.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write # Required for reusable workflow jobs to checkout the caller repo and push coverage reports to gh-pages.
+      pull-requests: write # Required for reusable workflow PR comment steps (coverage summary).
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Output uses only bash and github.repository context; no GitHub token API calls.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write # Required for reusable workflow jobs to checkout the caller repo and push coverage reports to gh-pages.
       pull-requests: write # Required for reusable workflow PR comment steps (coverage summary).
+    timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read # Required for actions/checkout to clone the repository.
       actions: write # Required for actions/cache to restore and save the Composer dependency cache.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required for actions/checkout to clone the repository.
+      actions: write # Required for actions/cache to restore and save the Composer dependency cache.
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -23,8 +23,8 @@ jobs:
     name: Prepare Release
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
-        contents: write
-        pull-requests: write
+      contents: write      # Required for the reusable workflow to push release preparation commits or branches on the caller repository.
+      pull-requests: write # Required for the reusable workflow to create or update the preparation pull request.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push release preparation commits or branches on the caller repository.
       pull-requests: write # Required for the reusable workflow to create or update the preparation pull request.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Steps use only secrets.WEBHOOK_TOKEN for repository-dispatch; the default GITHUB_TOKEN is not used against the GitHub API.
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # Steps use only secrets.WEBHOOK_TOKEN for repository-dispatch; the default GITHUB_TOKEN is not used against the GitHub API.
+    timeout-minutes: 10
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-performance/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-performance/.github/workflows/satis-update.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-performance/.github/workflows/lint.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-performance/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-performance/.github/workflows/newfold-prep-release.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-performance/.github/workflows/auto-translate.yml`) |
| Branch | `add/scoped-workflow-permissions` (created \| already existed \| not created — no changes needed) → **created** |
| Permissions commit | **8b035fe** |
| Timeouts commit | **3a8bee3** |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` (replaced non-empty workflow-level defaults with the mandated empty default block and comment ahead of `jobs:`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (replaced workflow-level `contents: read` with the mandated empty default block and comment ahead of `jobs:`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` (replaced bare `permissions: {}` with the mandated two-line comment plus `permissions: {}` ahead of `jobs:`) |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive matching the audited pattern (explicit minimal scopes plus per-permission rationale comments) | Setup | `permissions: {}` (previously relied on workflow-level token default) [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive matching the audited pattern (explicit minimal scopes plus per-permission rationale comments) | Bluehost Build and Test Cypress | `contents: read` with inline rationale (previously unannotated `contents: read`) [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive matching the audited pattern (explicit minimal scopes plus per-permission rationale comments) | Bluehost DEV Build and Test Playwright | `contents: read` with inline rationale [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive matching the audited pattern (explicit minimal scopes plus per-permission rationale comments) | Hostgator Build and Test Playwright | `contents: read` with inline rationale (job previously had no explicit `permissions:`) [3] |
| satis-update.yml | 1 job | Send Webhook | `permissions: {}` [3] |
| lint.yml | 1 job | Run PHP Code Sniffer | `contents: read`, `actions: write` [2] |
| codecoverage-main.yml | 2 jobs | get-repo-name | `permissions: {}` (previously inherited workflow-level repo read implicitly) [3] |
| codecoverage-main.yml | 2 jobs | codecoverage | `contents: write`, `pull-requests: write` with inline rationales (scopes existed; rationales added; `uses:` ordering normalized) [3] |
| newfold-prep-release.yml | `prep-release` -> existing write scopes retained with corrected alignment and explicit per-scope comments [3] | — | — |
| auto-translate.yml | `translate` -> scopes retained with normalized `uses:`/`permissions:` layout and explicit per-scope comments [3] | — | — |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `brand-plugin-test-playwright.yml` :: workflow default: BEFORE `permissions: contents: read` -> AFTER mandated empty default `permissions: {}` plus preamble comments ahead of `jobs:` — centralized `contents: read` masked least-privilege for the setup job — [3] |
| 2 | `codecoverage-main.yml` :: workflow default: BEFORE `permissions: contents: read` -> AFTER mandated empty default `permissions: {}` plus preamble comments — avoid granting repository read to helper jobs via workflow defaults alone — [3] |
| 3 | (no other behavioural scope errors identified beyond clarifying commentary/structure) |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| brand-plugin-test-playwright.yml | Setup | `10` | Lightweight branch/metadata extraction without checkout; tight cap prevents orphaned dispatch wiring from running indefinitely. |
| brand-plugin-test-playwright.yml | Bluehost Build and Test Cypress | `90` | Matches the callee reusable Playwright smoke job’s heavier build plus browser installation headroom versus the callee’s inner `timeout-minutes: 45` matrix step. |
| brand-plugin-test-playwright.yml | Bluehost DEV Build and Test Playwright | `90` | Same rationale as sibling brand Playwright callers. |
| brand-plugin-test-playwright.yml | Hostgator Build and Test Playwright | `90` | Same rationale as sibling brand Playwright callers. |
| satis-update.yml | Send Webhook | `10` | Three short bash metadata steps plus a single PAT-backed dispatch should finish quickly unless networking regresses catastrophically. |
| lint.yml | Run PHP Code Sniffer | `30` | Composer install plus PHPCS on a PHP diff subset should remain well under typical GitHub-hosted runner quotas. |
| codecoverage-main.yml | get-repo-name | `5` | Single echo step deriving the repository basename from contexts is bounded work. |
| codecoverage-main.yml | codecoverage | `60` | Reusable workflow runs a multi-version PHPUnit/Codeception matrix in parallel capped at 45 minutes internally; caller allows modest slack for queued scheduling and teardown. |
| newfold-prep-release.yml | Prepare Release | `30` | Automated release-preparation reused workflow stays bounded absent manual intervention stalls. |
| auto-translate.yml | Check and update translations | `30` | Translation regeneration and bot-driven PR tooling should converge within typical half-hour tooling budgets unless upstream translation services throttle heavily. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | GitHub workflow permissions documentation fetch from `https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions` timed out; `lint.yml`’s inclusion of `actions: write` for `actions/cache` is based on upstream action docs patterns and warrants a human glance if caching ever errors with narrowed scopes [2]. |
| 2 | Reusable workflows in `newfold-labs/workflows` were assessed via local clones available in this workspace (`reusable-codecoverage.yml`, `module-plugin-test-playwright.yml`); callers were aligned to those behaviours without re-pinning hashes [3]. |
| 3 | `peter-evans/repository-dispatch` consumes `secrets.WEBHOOK_TOKEN` only — default `GITHUB_TOKEN` API scopes are deliberately empty on that job — [3]. |
| 4 | [REDACTED] |


