### PR TITLE
Fix capability test helper to include canAccessAI marker

### DIFF
--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -222,15 +222,6 @@ async function runWpCli(command) {
   };
 }
 
-function toPhpArray(capabilities) {
-  return Object.entries(capabilities)
-    .map(([key, value]) => {
-      const phpValue = typeof value === 'boolean' ? value.toString() : `'${value}'`;
-      return `'${key}' => ${phpValue}`;
-    })
-    .join(', ');
-}
-
 async function verifySiteCapabilities(expectedCapabilities) {
   const result = await runWpCli('option get _transient_nfd_site_capabilities --format=json');
   if (!result.ok) {
@@ -267,7 +258,7 @@ async function verifySiteCapabilities(expectedCapabilities) {
 // ============================================================================
 
 /**
- * Set site capabilities transient using PHP eval
+ * Set site capabilities transient using the plugin's shared setCapability helper
  * @param {Object} capabilities - Object with capability key-value pairs
  * @example setSiteCapabilities({ hasLinkPrefetchClick: true, hasLinkPrefetchHover: false })
  */
@@ -279,26 +270,22 @@ export async function setSiteCapabilitiesWithRetry(
   capabilities,
   retries = DEFAULT_CAPABILITY_RETRIES,
 ) {
-  // wp-module-data's SiteCapabilities::is_valid_capabilities() only accepts a
-  // capabilities array as a real Hiive response if it contains the canAccessAI
-  // marker key; otherwise all() discards it and falls back to an (empty, in CI)
-  // Hiive fetch. Include the marker so the value we set here is actually read
-  // back by SiteCapabilities::all() instead of being silently dropped.
-  const phpArray = toPhpArray({ canAccessAI: true, ...capabilities });
   let lastReason = '';
 
   for (let attempt = 1; attempt <= retries; attempt += 1) {
-    const setResult = await runWpCli(
-      `eval "set_transient('nfd_site_capabilities', array(${phpArray}), 4 * HOUR_IN_SECONDS);"`,
-    );
-    if (!setResult.ok) {
-      lastReason = setResult.output;
-    } else {
+    try {
+      // Delegate to the plugin's shared helper so the canAccessAI marker
+      // requirement (wp-module-data SiteCapabilities::is_valid_capabilities(),
+      // see newfold-labs/wp-module-data#285) is handled in one place instead
+      // of being duplicated in every module's own test helper.
+      await newfold.setCapability(capabilities);
       const verify = await verifySiteCapabilities(capabilities);
       if (verify.ok) {
         return { ok: true, reason: '' };
       }
       lastReason = verify.reason;
+    } catch (error) {
+      lastReason = error?.message || String(error);
     }
 
     fancyLog(

--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -279,7 +279,12 @@ export async function setSiteCapabilitiesWithRetry(
   capabilities,
   retries = DEFAULT_CAPABILITY_RETRIES,
 ) {
-  const phpArray = toPhpArray(capabilities);
+  // wp-module-data's SiteCapabilities::is_valid_capabilities() only accepts a
+  // capabilities array as a real Hiive response if it contains the canAccessAI
+  // marker key; otherwise all() discards it and falls back to an (empty, in CI)
+  // Hiive fetch. Include the marker so the value we set here is actually read
+  // back by SiteCapabilities::all() instead of being silently dropped.
+  const phpArray = toPhpArray({ canAccessAI: true, ...capabilities });
   let lastReason = '';
 
   for (let attempt = 1; attempt <= retries; attempt += 1) {


### PR DESCRIPTION
## Proposed changes

`tests/playwright/helpers/index.mjs`'s `setSiteCapabilitiesWithRetry()` now delegates to the plugin's shared `newfold.setCapability()` helper (imported the same way this module already imports `wordpress`/`auth`/`utils` from the plugin) instead of building its own PHP array and calling `set_transient()` via `eval`.

### Root cause

`wp-module-data`'s `SiteCapabilities::is_valid_capabilities()` (added by [wp-module-data#285](https://github.com/newfold-labs/wp-module-data/pull/285), "Fix poisoned capabilities cache before and after Hiive connect") only treats a capabilities array as a genuine Hiive response if it contains the `canAccessAI` key (`SiteCapabilities::HIIVE_RESPONSE_MARKER`). Without that key, `SiteCapabilities::all()` discards whatever was cached and falls back to a live Hiive fetch — which fails in CI (no Hiive connection), returning an empty array.

This module's own `LinkPrefetch.php` calls `(new SiteCapabilities())->all()` to compute `hasLinkPrefetchClick`/`hasLinkPrefetchHover` for the frontend. Since the test helper set the transient directly via `set_transient()` without the marker key, `all()` silently discarded it, both capabilities came back `null`, and the frontend (`src/components/App/index.js`) defaults both to `true` when the key is absent — so the dropdown always rendered both options regardless of what the test asked for.

This was hidden while `wp-plugin-bluehost` pinned `wp-module-data` at 2.9.4 (which predates the `is_valid_capabilities()` gate), but surfaces as soon as the module is bumped to 2.9.5+ — currently breaking `performance.spec.mjs`'s `hasLinkPrefetchClick capability shows only mouseDown option` test in [wp-plugin-bluehost#1387](https://github.com/newfold-labs/wp-plugin-bluehost/pull/1387) and [wp-module-data#293](https://github.com/newfold-labs/wp-module-data/pull/293).

### Fix

Rather than duplicating the `canAccessAI` marker workaround locally (the initial commit here did this via a local object merge before building the PHP array), the helper now calls the plugin's own `newfold.setCapability()` — which already handles the marker default (see `wp-plugin-bluehost`'s `tests/playwright/helpers/newfold.mjs`) — so the fix lives in one place instead of being copied into every module's test helper. All call sites (`setSiteCapabilities`, `setLinkPrefetchCapabilities`) go through this function, so no spec changes are needed.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Further comments

Related: [wp-module-data#285](https://github.com/newfold-labs/wp-module-data/pull/285), [wp-plugin-bluehost#1387](https://github.com/newfold-labs/wp-plugin-bluehost/pull/1387), [wp-module-data#293](https://github.com/newfold-labs/wp-module-data/pull/293)
